### PR TITLE
No longer require system-wide install of phpdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 composer.lock
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+composer.lock

--- a/Command/DocumentorCommand.php
+++ b/Command/DocumentorCommand.php
@@ -51,7 +51,8 @@ class DocumentorCommand extends ContainerAwareCommand {
         $source = realpath($rootDir . '/../src');
         $target = realpath(__DIR__ . '/../Resources/public');
         
-        $command = 'phpdoc -d ' . $source . ' -t ' . $target;
+        $phpDocPath = realpath($rootDir . '/../bin/phpdoc.php');
+        $command = $phpDocPath . ' -d ' . $source . ' -t ' . $target;
         
         $process = new Process($command);
         $process->setTimeout(3600);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
 
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "phpdocumentor/phpdocumentor": "dev-master"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "autoload": {
         "psr-0": { "Aga\\DocumentorBundle": "" }
     },
-    
+
     "target-dir": "Aga/DocumentorBundle"
 
 }


### PR DESCRIPTION
Allows generating documentation without needing `phpdoc` installed system-wide.

Instead, we can add `phpdocumentor/phpdocumentor` as a Composer dependency of the bundle, so it will be installed along with the bundle. Now the bundle uses the `phpdoc` executable installed at `./bin/phpdoc.php`

BUT the phpDocumentor2 project is still working through the issues to properly install it via Composer. **There is at least 1 bug that must be resolved before this PR can be merged**, and also 1 feature request relative to how the developers think the project should be updated we should keep tabs on:

**Blocking Bug:** phpDocumentor/phpDocumentor2#597 - Templates being installed into project root when installed via composer

**Relative Feature:** phpDocumentor/phpDocumentor2#609 - Add command to update phpDocumentor
