### PR TITLE
Add ability to use config file in root directory

### DIFF
--- a/Command/DocumentorCommand.php
+++ b/Command/DocumentorCommand.php
@@ -51,7 +51,12 @@ class DocumentorCommand extends ContainerAwareCommand {
         $source = realpath($rootDir . '/../src');
         $target = realpath(__DIR__ . '/../Resources/public');
         
-        $command = 'phpdoc -d ' . $source . ' -t ' . $target;
+        $configFile = realpath($rootDir . '/../phpdoc.dist.xml');
+        if (file_exists($configFile)) {
+            $command = 'phpdoc -c ' . $configFile . ' -t ' . $target;
+        } else {
+            $command = 'phpdoc -d ' . $source . ' -t ' . $target;
+        }
         
         $process = new Process($command);
         $process->setTimeout(3600);


### PR DESCRIPTION
Check if there's a phpdoc.dist.xml in the root directory and use that as a base for config (still overwriting the target directory for consistency)
